### PR TITLE
Enable push to Coveralls despite failing tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,3 +30,7 @@ jobs:
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2
+      # According to this StackOverflow question:
+      # https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f
+      # this should allow the step to run even if the previous step fails, but also enable cancelling the workflow.
+      if: '!cancelled()'


### PR DESCRIPTION
Added an if statement to Coveralls step to try and force the step to run despite failing tests